### PR TITLE
fix/11-sync locale to the redux store on app top-level

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -20,6 +20,7 @@ import {
   routesMetadata,
 } from "@/constants/metadata.constant";
 import { Locale } from "@/types/locale";
+import ReduxLocaleSync from "@/components/ReduxLocaleSync";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -32,7 +33,7 @@ const notoKufiArabic = Noto_Kufi_Arabic({
 export async function generateMetadata({
   params,
 }: {
-  params:  Promise<{ locale: Locale | string }>;
+  params: Promise<{ locale: Locale | string }>;
 }): Promise<Metadata> {
   const { locale } = await params;
   const isArabic = isArabicLocale(locale);
@@ -91,7 +92,10 @@ export default async function LocaleLayout({
                   />
                   <NuqsAdapter>
                     <GeneralContextProvider>
-                      <ReduxProvider>{children}</ReduxProvider>
+                      <ReduxProvider>
+                        <ReduxLocaleSync />
+                        {children}
+                      </ReduxProvider>
                     </GeneralContextProvider>
                   </NuqsAdapter>
                 </HomeEffectsContextProvider>

--- a/src/components/ReduxLocaleSync.tsx
+++ b/src/components/ReduxLocaleSync.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect } from "react";
+import { useLocale } from "next-intl";
+import { useDispatch } from "react-redux";
+import { setLocale } from "@/redux/slices/general";
+import { Locale } from "@/types/locale";
+
+export default function ReduxLocaleSync() {
+  const locale = useLocale();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(setLocale(locale as Locale));
+  }, [locale, dispatch]);
+
+  return null;
+}

--- a/src/config/imageDomains.ts
+++ b/src/config/imageDomains.ts
@@ -3,6 +3,4 @@ export const imageDomains =
     domain.replace("https://", "").replace("http://", "").trim()
   ) || [];
 
-console.log("Loaded Image Domains:", imageDomains);
-
 export default imageDomains;


### PR DESCRIPTION
=> Description: Syncing locale to the store even when the path changes using Single Source of Truth = URL / next-intl locale.